### PR TITLE
Easy changes from Angela's first email

### DIFF
--- a/Activities.html
+++ b/Activities.html
@@ -67,10 +67,10 @@
 	<ul>
 
 		<li>FISH on Kootenay Lake: some of the best fishing in British Columbia (see <a href="Fishing.html">Fishing</a>)</li></ul><ul>
-		<li>Crystal clear water, great for swimming, boating, wakeboarding, skiing, <a href="http://www.kaslokayaking.ca" TARGET="_new">kayaking</a>, canoeing and windsurfing</li></ul><ul>
+		<li>Crystal clear water, great for swimming, boating, wakeboarding, skiing, <a href="kaslokayaking.com" TARGET="_new">kayaking</a>, canoeing and windsurfing</li></ul><ul>
 		<li>Visit the nearby picturesque town of Kaslo (major grocery store, museum, shops, restaurants, artists, other services) (see <a href="Kaslo.html">Kaslo</a>)</li></ul><ul>
 		<li>Go soak in <a href="http://www.hotnaturally.com/" TARGET="_new">Ainsworth Hot Springs</a>: only 30 km away</li></ul><ul>
-		<li>GOLF at <a href="http://www.kokaneesprings.com/" TARGET="_new">Kokanee Springs</a>, <a href="http://www.golfbalfour.com/" TARGET="_new">Balfour</a> and <a href="http://www.kaslogolf.org/index.html" TARGET="_new">Kaslo</a> Golf clubs</li></ul><ul>
+		<li>GOLF at <a href="http://www.kokaneesprings.com/" TARGET="_new">Kokanee Springs</a>, <a href="http://www.golfbalfour.com/" TARGET="_new">Balfour</a> and <a href="http://www.kaslogolf.org" TARGET="_new">Kaslo Golf Club</a></li></ul><ul>
 		<li>ATV trails</li></ul><ul>
 		<li><a href="http://www.bcadventure.com/adventure/explore/kootenays/trails/kohaneep.htm" TARGET="_new">Hiking </a>trails</li></ul><ul>
 <li>Kaslo <a href="https://kaslojazzfest.com" TARGET="_new">Jazz fest</a></li></ul><ul>

--- a/Amenities.html
+++ b/Amenities.html
@@ -75,6 +75,7 @@
 		<li>Beautiful treed sites</li></ul><ul>
 		<li>Easy access for larger RV units, with full hook-ups</li></ul><ul>
 		<li>Shady spacious tent sites</li></ul><ul>
+		<li>Wifi available</li></ul><ul>
 		<li>Sani dump for campers</li></ul><ul>
 		<li>Sheltered marina and boat ramp</li></ul><ul>
 		<li>On-site holiday trailers available for rent</li></ul><ul>

--- a/Rates.html
+++ b/Rates.html
@@ -68,7 +68,7 @@
 
 		<ul>
 			<li>Reasonable daily, weekly and monthly rates available</li>
-			<li>Rates as of 2017 (not including gst) are:</li>
+			<li>Rates as of 2018 (not including gst) are:</li>
 		</ul><ul><ul>
 
 
@@ -148,7 +148,7 @@
 <table width="80%" border="0" cellspacing="0" cellpadding="0" align="center">
 <tr>
 	<br>
-		<td align="Center"><FONT Size = 2><FONT face='Copperplate Gothic Bold'><p>(Owned and operated by Blackpaw Ventures Inc. Copyright &copy; <span class="current-year">2017</span> Black Paw Ventures Inc.)</td>
+		<td align="Center"><FONT Size = 2><FONT face='Copperplate Gothic Bold'><p>(Owned and operated by Blackpaw Ventures Inc. Copyright &copy; <span class="current-year">2018</span> Black Paw Ventures Inc.)</td>
 </tr>
 </table>
 

--- a/index.html
+++ b/index.html
@@ -69,9 +69,11 @@
 			<li>Picturesque beach on Kootenay Lake</li>
 			<li>Full service RV, Trailer and Tenting sites are available</li>
 			<li>Rental cabin (2 bedroom), available on a weekly basis</li>
+			<li>On-site holiday trailers available for rent</li>
 			<li>Marina slips and boat fuel available</li>
+			<li>WiFi available</li>
 			<li>Also near many attractions:</li><ul>
-			<li>The beautiful town of Kaslo</li>
+			<li>The beautiful Village of Kaslo</li>
 			<li>Golf at Kokanee Springs, Balfour and Kaslo Golf clubs</li>
 			<li>Natural hot springs at Ainsworth Hot Springs</li>
 			<li>Numerous hiking trails</li>


### PR DESCRIPTION
# Changes

## Home Page

1. Add new bullet “On-site holiday trailers available for rent” after 5th bullet that reads “Rental cabin (2 bedroom)…..”
2. Add new bullet “WiFi available” after 6th bullet that reads “Marina slips and boat fuel available”
3. Last bullet - first sub-bullet should read “Village of Kaslo” instead of “town of Kaslo”


## Amenities Page

1. Add new bullet “Wifi available” after third bullet that reads “Shady spacious tent sites”

## Activities Page

1. Second bullet - Link to kayaking website should be kaslokayaking.com
2. Fifth bullet - 
  a) check link for Kaslo golf and update if need be - address correct but Error 404 message also appears
  b) The link should be “Kaslo Golf” instead of “Kaslo” (so it’s not the same as the link to the Village website)

## Rates Page

1. In second bullet change 2017 to 2018